### PR TITLE
Fixed DatePicker-Ranges not working

### DIFF
--- a/app/views/clients/activity.html.slim
+++ b/app/views/clients/activity.html.slim
@@ -11,7 +11,7 @@ p = link_to "http://#{absolute_path activity_client_path(@client, client_token: 
       = f.input :end_date, as: :date_picker
     .col-xs-6.col-md-3
       = f.input :specific_range, as: :select,
-        collection: ClientAggregator::RANGE_VALUES, label_method: ->(o) { t(o) }, default: ''
+        collection: ClientAggregator::RANGE_VALUES, label_method: ->(o) { t(o) }
     .col-xs-6.col-md-3
       .aligned-submit-button
         = f.button :submit, "Submit", class: "btn-primary"

--- a/app/views/expenses/_form.html.slim
+++ b/app/views/expenses/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for @expense do |f|
   .row
     .col-md-3
-      = f.input :client_id, collection: current_user.clients, default: ''
+      = f.input :client_id, collection: current_user.clients
     .col-md-3
       = f.input :total
   = f.input :reason

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -1,6 +1,6 @@
 = simple_form_for @note do |f|
   #wmd-button-bar
   = f.input :content, input_html: {class: "col-md-12 wmd-input", id: "wmd-input"}
-  = f.input :client_id, collection: current_user.clients, default: ''
+  = f.input :client_id, collection: current_user.clients
   .form-actions
     = f.button :submit

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -26,7 +26,7 @@
         = f.input :city
         = f.input :zip
         = f.input :currency, :as => :select, :collection => Money::Currency.pretty_currency_names, label_method: :first, value_method: :last, include_blank: false
-        = f.input :time_zone, label: "Timezone", default: ''
+        = f.input :time_zone, label: "Timezone"
 
     .form-actions
       .btn-group


### PR DESCRIPTION
Due to `default: ''` within the select-fields AngularJS automatically throws the first, empty option in a selectbox away, hence the user could not select "no pre-selected range" anymore.
