### PR TITLE
Team specific statistics

### DIFF
--- a/app/assets/javascripts/angular/worklogs/user.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/user.js.coffee
@@ -1,0 +1,20 @@
+app = angular.module("app")
+
+app.factory "User", ["RailsResource", (RailsResource)->
+  class User extends RailsResource
+    @configure url: '/users', name: 'user'
+    constructor: (opts = {})->
+      defaultOpts =
+        username: ""
+      _this = this
+      useOpts = _.extend defaultOpts, opts
+      _.each useOpts, (val, key) ->
+        _this[key] = val
+
+    usernameOrErrorString: ->
+      if @user.username.length
+        "#{@user.username}"
+      else
+        "No Username available"
+  User
+]

--- a/app/assets/javascripts/angular/worklogs/worklog.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/worklog.js.coffee
@@ -21,6 +21,7 @@ app.factory "Worklog", ["RailsResource", "Timeframe", "railsSerializer", "Client
         sharedClients: []
         clientId: null
         client: null
+        # teams: []
         hourlyRate: 0
         comment: ""
         id: null

--- a/app/assets/javascripts/angular/worklogs/worklog.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/worklog.js.coffee
@@ -21,7 +21,6 @@ app.factory "Worklog", ["RailsResource", "Timeframe", "railsSerializer", "Client
         sharedClients: []
         clientId: null
         client: null
-        # teams: []
         hourlyRate: 0
         comment: ""
         id: null

--- a/app/assets/javascripts/angular/worklogs/worklog.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/worklog.js.coffee
@@ -41,16 +41,22 @@ app.factory "Worklog", ["RailsResource", "Timeframe", "railsSerializer", "Client
         last_started = _.last(@timeframes).started
         if last_started
           t.started = new Date(last_started)
+          t.started.setSeconds(0,0)
         else
           t.started = new Date
+          t.started.setSeconds(0,0)
         last_ended = _.last(@timeframes).ended
         if last_ended
           t.ended = new Date(last_ended)
+          t.ended.setSeconds(0,0)
         else
           t.ended = new Date
+          t.ended.setSeconds(0,0)
       else
         t.started = new Date
         t.ended = new Date
+        t.started.setSeconds(0,0)
+        t.ended.setSeconds(0,0)
       @addNewTimeframe t
 
     calcTotal: ->

--- a/app/assets/javascripts/angular/worklogs/worklogs_controller.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/worklogs_controller.js.coffee
@@ -1,12 +1,11 @@
 app = angular.module("app")
 
-app.controller "WorklogsController", ["$scope", "$q", "Worklog", "Client", ($scope, $q, Worklog, Client)->
+app.controller "WorklogsController", ["$scope", "$q", "Worklog", "Client", "User", ($scope, $q, Worklog, Client, User)->
   $scope.init = ->
     $scope.hstep = 1
     $scope.mstep = 10
     $scope.clients = []
-    # How to fetch all teams of the current user?
-    # $scope.teams = []
+    $scope.currentUser = null
     $scope.dateOptions =
       formatYear: "yy"
       startingDay: 1
@@ -15,14 +14,17 @@ app.controller "WorklogsController", ["$scope", "$q", "Worklog", "Client", ($sco
     # Only fetch worklog if it is present
     query = _.select [
       Client.query({}),
+      User.get(gon.current_user_id),
       if idPresent then Worklog.get(gon.worklog_id) else null
     ], (e)->
       e
 
     $q.all(query).then (results)->
       $scope.clients = results[0]
+      $scope.currentUser = results[1]
+
       if idPresent
-        $scope.worklog = results[1]
+        $scope.worklog = results[2]
       else
         $scope.worklog = new Worklog
 

--- a/app/assets/javascripts/angular/worklogs/worklogs_controller.js.coffee
+++ b/app/assets/javascripts/angular/worklogs/worklogs_controller.js.coffee
@@ -5,6 +5,8 @@ app.controller "WorklogsController", ["$scope", "$q", "Worklog", "Client", ($sco
     $scope.hstep = 1
     $scope.mstep = 10
     $scope.clients = []
+    # How to fetch all teams of the current user?
+    # $scope.teams = []
     $scope.dateOptions =
       formatYear: "yy"
       startingDay: 1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,11 @@ class UsersController < ApplicationController
   end
 
   def show
+    respond_to do |format|
+      format.html {}
+      format.json { render json: current_user }
+    end
+
   end
 
   def signup_email

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,9 +28,8 @@ class UsersController < ApplicationController
   def show
     respond_to do |format|
       format.html {}
-      format.json { render json: current_user }
+      format.json { render json: current_user, include: :teams }
     end
-
   end
 
   def signup_email

--- a/app/controllers/worklogs_controller.rb
+++ b/app/controllers/worklogs_controller.rb
@@ -52,7 +52,12 @@ class WorklogsController < ApplicationController
 
   def update
     @worklog = current_user.worklogs.find(params[:id])
-    form = WorklogForm.new_from_params(params[:worklog], user: current_user, worklog: @worklog)
+    if (params[:worklog][:team_id].present?)
+      @team = Team.find(params[:worklog][:team_id])
+    else
+      @team = nil
+    end
+    form = WorklogForm.new_from_params(params[:worklog], user: current_user, worklog: @worklog, team: @team)
     if form.save
       render json: form.worklog, status: 200, root: "worklog"
     else

--- a/app/forms/team_invite_form.rb
+++ b/app/forms/team_invite_form.rb
@@ -7,7 +7,7 @@ class TeamInviteForm
   attribute :username
   attribute :inviter
 
-  validate :inviter, :team, :user, presence: true
+  validates :inviter, :team, :user, presence: true
   validate :team_must_belong_to_inviter
   validate :user_must_exist
   validate :user_may_not_be_in_team_already

--- a/app/forms/worklog_form.rb
+++ b/app/forms/worklog_form.rb
@@ -13,6 +13,9 @@ class WorklogForm
   attribute :client, Client
   attribute :total, Numeric
 
+  attribute :team_id, Numeric
+  attribute :team, Team
+
   validates :user, presence: true
   validates :client, presence: true
   validates :hourly_rate, numericality: {greater_than: 0}
@@ -20,8 +23,9 @@ class WorklogForm
   validates :comment, presence: true
   validate :timeframes_validator
 
-  def self.new_from_params(params, user: nil, worklog: nil)
+  def self.new_from_params(params, user: nil, worklog: nil, team: nil)
     obj = new(params)
+    obj.team = team
     obj.user = user
     obj.worklog = worklog
     obj
@@ -63,6 +67,7 @@ class WorklogForm
     use_worklog.hourly_rate = Money.new hourly_rate.to_f * 100
     use_worklog.summary     = comment
     use_worklog.user        = user
+    use_worklog.team        = team
     use_worklog.client      = client
     use_worklog.timeframes  = timeframes
     use_worklog.total       = Money.new total.to_f * 100

--- a/app/models/worklog.rb
+++ b/app/models/worklog.rb
@@ -17,7 +17,8 @@ class Worklog < ActiveRecord::Base
     :from_date,
     :from_time,
     :to_date,
-    :to_time
+    :to_time,
+    :team_id
 
   attr_accessor :from_date,
     :from_time,
@@ -34,6 +35,7 @@ class Worklog < ActiveRecord::Base
   belongs_to :client
   belongs_to :client_share
   belongs_to :invoice
+  belongs_to :team
   has_many :timeframes
 
   validates :user, :client, presence: true

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,0 +1,3 @@
+class TeamSearializer < ApplicationSerializer
+  attributes :id, :name
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSearializer < ApplicationSerializer
+  attributes :id, :teams
+end

--- a/app/serializers/worklog_serializer.rb
+++ b/app/serializers/worklog_serializer.rb
@@ -1,7 +1,8 @@
 class WorklogSerializer < ActiveModel::Serializer
-  attributes :id, :comment, :hourly_rate, :client_id, :timeframes, :total
+  attributes :id, :comment, :hourly_rate, :client_id, :team_id, :timeframes, :total
 
   belongs_to :client
+  # belongs_to :team
 
   def comment
     object.summary

--- a/app/services/team_aggregator.rb
+++ b/app/services/team_aggregator.rb
@@ -77,8 +77,8 @@ class TeamAggregator
     use_worklogs = worklogs user
     {
       username: user.username,
-      seconds_worked: use_worklogs.map(&:duration).inject(:+) || 0,
-      total_cents: use_worklogs.map(&:total_cents).inject(:+) || 0,
+      seconds_worked: use_worklogs.where(team_id: team).map(&:duration).inject(:+) || 0,
+      total_cents: use_worklogs.where(team_id: team).map(&:total_cents).inject(:+) || 0,
       currency: (user.currency || Money.default_currency)
     }
   end

--- a/app/views/worklogs/_form.html.slim
+++ b/app/views/worklogs/_form.html.slim
@@ -24,7 +24,12 @@ div ng-controller="WorklogsController"
       label Client
       select.form-control ng-model="worklog.client" ng-options="client.nameOrCompanyName() for client in clients | orderBy:'nameOrCompanyName()' track by client.id" ng-change="worklog.clientChanged()"
         option value="" ng-if="false"
-    .col-xs-5 ng-hide="worklog.client.shared"
+    .col-xs-3
+      label Team
+      / Populate the view with all teams the user is part of (through Angular)
+      select.form-control
+        option value="" ng-if="false"
+    .col-xs-2 ng-hide="worklog.client.shared"
       label Hourly rate
       input.form-control type="text" ng-model="worklog.hourlyRate"
     .col-xs-2 ng-hide="worklog.client.shared"

--- a/app/views/worklogs/_form.html.slim
+++ b/app/views/worklogs/_form.html.slim
@@ -26,9 +26,9 @@ div ng-controller="WorklogsController"
         option value="" ng-if="false"
     .col-xs-3
       label Team
-      / Populate the view with all teams the user is part of (through Angular)
-      select.form-control
-        option value="" ng-if="false"
+      select.form-control ng-model="worklog.teamId" ng-options="team.id as team.name for team in currentUser.teams"
+        option value=""
+
     .col-xs-2 ng-hide="worklog.client.shared"
       label Hourly rate
       input.form-control type="text" ng-model="worklog.hourlyRate"

--- a/app/views/worklogs/index.html.slim
+++ b/app/views/worklogs/index.html.slim
@@ -21,6 +21,7 @@ table.table.table-bordered
       th.hidden-phone End
       th Duration
       th.hidden-phone Price
+      th Team
       th Controls
   tbody
     - @worklogs.each do |worklog|
@@ -31,6 +32,9 @@ table.table.table-bordered
         td.hidden-phone= l worklog.end_time, format: :short
         td= worklog.duration_hours_minutes
         td.hidden-phone= with_currency worklog.total
+        td
+          - if worklog.team.present?
+            = worklog.team.name.to_s
         td
           .btn-group.pull-right
             = link_to 'Edit', edit_worklog_path(worklog), class: "btn btn-default"

--- a/db/migrate/20160714160518_add_team_id_to_worklogs.rb
+++ b/db/migrate/20160714160518_add_team_id_to_worklogs.rb
@@ -1,0 +1,6 @@
+class AddTeamIdToWorklogs < ActiveRecord::Migration
+  def change
+    add_column :worklogs, :team_id, :integer
+    add_foreign_key :worklogs, :teams, column: :team_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,60 +11,60 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160411171919) do
+ActiveRecord::Schema.define(version: 20160714160518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "access_tokens", force: true do |t|
-    t.string   "token"
-    t.boolean  "expirable",        default: true
+  create_table "access_tokens", force: :cascade do |t|
+    t.string   "token",            limit: 255
+    t.boolean  "expirable",                    default: true
     t.datetime "last_activity_at"
     t.integer  "user_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
   end
 
-  create_table "add_attributes_to_users", force: true do |t|
-    t.string   "first_name"
-    t.string   "last_name"
+  create_table "add_attributes_to_users", force: :cascade do |t|
+    t.string   "first_name", limit: 255
+    t.string   "last_name",  limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "authentications", force: true do |t|
+  create_table "authentications", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "uid"
-    t.string   "provider"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "provider",   limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
-  create_table "client_shares", force: true do |t|
+  create_table "client_shares", force: :cascade do |t|
     t.integer  "client_id"
     t.integer  "user_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.string   "username"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.string   "username",          limit: 255
     t.integer  "hourly_rate_cents"
   end
 
-  create_table "clients", force: true do |t|
-    t.string   "name"
+  create_table "clients", force: :cascade do |t|
+    t.string   "name",                         limit: 255
     t.integer  "hourly_rate_cents"
-    t.integer  "user_id",                      null: false
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.string   "city"
-    t.string   "street"
-    t.string   "zip"
-    t.string   "company_name"
+    t.integer  "user_id",                                  null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.string   "city",                         limit: 255
+    t.string   "street",                       limit: 255
+    t.string   "zip",                          limit: 255
+    t.string   "company_name",                 limit: 255
     t.boolean  "email_when_team_adds_worklog"
-    t.string   "client_token"
+    t.string   "client_token",                 limit: 255
     t.text     "credit_block_reason"
   end
 
-  create_table "expenses", force: true do |t|
+  create_table "expenses", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "client_id"
     t.integer  "total_cents"
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.integer  "invoice_id"
   end
 
-  create_table "invoice_defaults", force: true do |t|
+  create_table "invoice_defaults", force: :cascade do |t|
     t.float    "vat"
     t.boolean  "includes_vat"
     t.text     "payment_terms"
@@ -85,17 +85,17 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.datetime "updated_at",    null: false
   end
 
-  create_table "invoices", force: true do |t|
+  create_table "invoices", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "client_id"
-    t.string   "number"
+    t.string   "number",         limit: 255
     t.integer  "total_cents"
     t.boolean  "includes_vat"
     t.datetime "paid_on"
     t.float    "vat"
     t.text     "note"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
     t.text     "content"
     t.text     "payment_terms"
     t.text     "payment_info"
@@ -104,21 +104,21 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.datetime "invoice_date"
   end
 
-  create_table "invoices_products", force: true do |t|
+  create_table "invoices_products", force: :cascade do |t|
     t.integer "product_id"
     t.integer "invoice_id"
   end
 
-  create_table "notes", force: true do |t|
+  create_table "notes", force: :cascade do |t|
     t.text     "content"
     t.integer  "user_id"
     t.integer  "client_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.string   "share_token"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.string   "share_token", limit: 255
   end
 
-  create_table "products", force: true do |t|
+  create_table "products", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "total_cents"
     t.float    "charge"
@@ -127,10 +127,10 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.datetime "updated_at",  null: false
   end
 
-  create_table "team_users", force: true do |t|
+  create_table "team_users", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "team_id"
-    t.string   "state"
+    t.string   "state",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -138,14 +138,14 @@ ActiveRecord::Schema.define(version: 20160411171919) do
   add_index "team_users", ["team_id"], name: "index_team_users_on_team_id", using: :btree
   add_index "team_users", ["user_id"], name: "index_team_users_on_user_id", using: :btree
 
-  create_table "teams", force: true do |t|
-    t.string   "name"
+  create_table "teams", force: :cascade do |t|
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "creator_id"
   end
 
-  create_table "teams_users", id: false, force: true do |t|
+  create_table "teams_users", id: false, force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "team_id"
     t.datetime "created_at"
@@ -155,21 +155,21 @@ ActiveRecord::Schema.define(version: 20160411171919) do
   add_index "teams_users", ["team_id"], name: "index_teams_users_on_team_id", using: :btree
   add_index "teams_users", ["user_id"], name: "index_teams_users_on_user_id", using: :btree
 
-  create_table "temp_worklog_saves", force: true do |t|
+  create_table "temp_worklog_saves", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.text     "summary"
-    t.string   "from_date"
-    t.string   "from_time"
-    t.string   "to_date"
-    t.string   "to_time"
+    t.string   "from_date",         limit: 255
+    t.string   "from_time",         limit: 255
+    t.string   "to_date",           limit: 255
+    t.string   "to_time",           limit: 255
     t.integer  "client_id"
     t.boolean  "show_user"
     t.integer  "hourly_rate_cents"
   end
 
-  create_table "timeframes", force: true do |t|
+  create_table "timeframes", force: :cascade do |t|
     t.datetime "started"
     t.datetime "ended"
     t.integer  "worklog_id"
@@ -177,34 +177,34 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.datetime "updated_at"
   end
 
-  create_table "users", force: true do |t|
-    t.string   "email",                                          null: false
-    t.string   "crypted_password"
-    t.string   "salt"
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "remember_me_token"
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                           limit: 255,                null: false
+    t.string   "crypted_password",                limit: 255
+    t.string   "salt",                            limit: 255
+    t.datetime "created_at",                                                 null: false
+    t.datetime "updated_at",                                                 null: false
+    t.string   "remember_me_token",               limit: 255
     t.datetime "remember_me_token_expires_at"
-    t.string   "reset_password_token"
+    t.string   "reset_password_token",            limit: 255
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
-    t.string   "city"
-    t.string   "street"
-    t.string   "zip"
-    t.string   "company_name"
-    t.string   "currency"
+    t.string   "city",                            limit: 255
+    t.string   "street",                          limit: 255
+    t.string   "zip",                             limit: 255
+    t.string   "company_name",                    limit: 255
+    t.string   "currency",                        limit: 255
     t.boolean  "signup_email_sent"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "time_zone"
-    t.string   "github_token"
-    t.string   "username"
-    t.boolean  "show_tutorial",                   default: true
+    t.string   "first_name",                      limit: 255
+    t.string   "last_name",                       limit: 255
+    t.string   "time_zone",                       limit: 255
+    t.string   "github_token",                    limit: 255
+    t.string   "username",                        limit: 255
+    t.boolean  "show_tutorial",                               default: true
   end
 
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", using: :btree
 
-  create_table "worklogs", force: true do |t|
+  create_table "worklogs", force: :cascade do |t|
     t.datetime "start_time"
     t.datetime "end_time"
     t.integer  "user_id"
@@ -217,6 +217,8 @@ ActiveRecord::Schema.define(version: 20160411171919) do
     t.integer  "invoice_id"
     t.datetime "deleted_at"
     t.integer  "client_share_id"
+    t.integer  "team_id"
   end
 
+  add_foreign_key "worklogs", "teams"
 end


### PR DESCRIPTION
This branch introduces a new feature. It allows the calculations inside a `team`-view to be truly related to the team. No more calculations of times (and costs) for worklogs a user created which were not related to a team.

This also means a user will have to edit the previous worklogs manually, but in the long run it causes profit :)