### PR TITLE
hid content if shared client

### DIFF
--- a/app/helpers/clients_helper.rb
+++ b/app/helpers/clients_helper.rb
@@ -1,2 +1,5 @@
 module ClientsHelper
+  def is_shared?(client)
+    !(current_user == client.user)
+  end
 end

--- a/app/views/clients/activity.html.slim
+++ b/app/views/clients/activity.html.slim
@@ -1,7 +1,8 @@
 h1.page-header Client: #{@client.name}
-p Share this link with your clients. They can then stay up to date on expenses and your daily work.
-p = link_to "http://#{absolute_path activity_client_path(@client, client_token: @client.client_token)}" do
-  | http://#{absolute_path activity_client_path(@client, client_token: @client.client_token)}
+- if logged_in? && !is_shared?(@client)
+  p Share this link with your clients. They can then stay up to date on expenses and your daily work.
+  p = link_to "http://#{absolute_path activity_client_path(@client, client_token: @client.client_token)}" do
+    | http://#{absolute_path activity_client_path(@client, client_token: @client.client_token)}
 = simple_form_for @form, url: activity_client_path(@client), method: :get do |f|
   = hidden_field_tag "client_token", @client.client_token
   .row
@@ -40,14 +41,19 @@ p = link_to "http://#{absolute_path activity_client_path(@client, client_token: 
                   span.timeframes = tfe.ended.to_formatted_s(:short)
               td = r.hours_formatted
               td = markdown r.worklog_summary
-              td.text-right = humanized_money_with_symbol r.total
-        tfoot
-          tr
-            td TOTAL:
-            td
-            td
-            td
-            td = @form.total_time
-            td
-            td.text-right
-              strong = humanized_money_with_symbol @form.total_costs
+              td.text-right
+                - if logged_in? && is_shared?(@client)
+                  | -
+                - else
+                  = humanized_money_with_symbol r.total
+        - unless is_shared?(@client)
+          tfoot
+            tr
+              td TOTAL:
+              td
+              td
+              td
+              td = @form.total_time
+              td
+              td.text-right
+                strong = humanized_money_with_symbol @form.total_costs


### PR DESCRIPTION
This is an addition to #20, where a user who had a shared client could still see the cost/price of their work, even if not necessarily allowed to.

With this commit a logged in user who has a shared client won't see the prices anymore, as well as the "share" link.
A client using the "share" link will see all the prices though.