### PR TITLE
Allow the user to customize the invoice layout with css

### DIFF
--- a/app/assets/stylesheets/invoices.css.sass
+++ b/app/assets/stylesheets/invoices.css.sass
@@ -43,8 +43,6 @@ $border-color: #d1d1d1
   margin-bottom: 90px
   padding-top: 30px
 .terms
-  h4, h5
-    color: $orange
   margin-top: 40px
   ul
     margin-left: 0px
@@ -55,7 +53,6 @@ $border-color: #d1d1d1
   margin-top: -21px
   padding-top: 15px
   .key
-    color: $orange
     margin-bottom: 13px
     text-transform: uppercase
     font-size: 11px
@@ -66,7 +63,6 @@ $border-color: #d1d1d1
     font-weight: normal
 .please-pay
   border-color: $orange
-  background: $orange
   .key, span
     color: #fff
 .invoice-writer
@@ -91,7 +87,6 @@ $border-color: #d1d1d1
 .invoice-total
   text-align: right
   .key
-    color: $orange
   .bold
     font-weight: bold
   .row
@@ -107,3 +102,7 @@ $border-color: #d1d1d1
 .right-selects
   select
     margin-top: 10px
+.colored-text
+  color: $orange
+.colored-background
+  background: $orange

--- a/app/models/invoice_default.rb
+++ b/app/models/invoice_default.rb
@@ -1,6 +1,6 @@
 class InvoiceDefault < ActiveRecord::Base
   include NilStrings
-  attr_accessible :includes_vat, :note, :payment_info, :payment_terms, :vat, :user_id
+  attr_accessible :includes_vat, :note, :payment_info, :payment_terms, :vat, :user_id, :custom_css
 
   belongs_to :user
   validates_uniqueness_of :user_id

--- a/app/views/invoice_default/edit.html.slim
+++ b/app/views/invoice_default/edit.html.slim
@@ -23,5 +23,11 @@
       #wmd-button-bar-third
       = f.input :note, label: false
     .col-md-12
+      h4
+        | Custom CSS for the invoice
+        '
+        small Apply custom rules to customize the look of your invoice.
+      = f.input :custom_css, label: false
+    .col-md-12
       hr.colorgraph
       = f.button :submit, "Save"

--- a/app/views/invoices/show.html.slim
+++ b/app/views/invoices/show.html.slim
@@ -14,7 +14,7 @@
     p= current_user.company_name
     p= current_user.street
     p= "#{current_user.zip} #{current_user.city}"
-  .col-xs-4
+  .col-xs-4.invoice-intro
     h3.intro hi. this is your invoice
 .row.invoice-client
   .col-xs-12
@@ -32,14 +32,14 @@
         h4= "#{@client.zip} #{@client.city}"
         h5.hide-for-print
           = link_to "(Edit details)", edit_client_path(@client)
-      .col-xs-2.invoice-box
+      .col-xs-2.invoice-box.colored
         span.key Number
         span.value #{@invoice.number}
-      .col-xs-2.invoice-box.please-pay
+      .col-xs-2.invoice-box.please-pay.colored-background
         span.key Please pay
         span.value.nowrap= with_currency @invoice.calc_vat_total
       .col-xs-2.invoice-box style="font-size: 13px"
-        span.key Invoice date
+        span.key.colored-text Invoice date
         - if @invoice.invoice_date
           span.value= l @invoice.invoice_date, format: :day_month_year
         - else
@@ -67,32 +67,32 @@
                 td.last= with_currency entry.total
 .invoice-total
   .row
-    .col-xs-3.col-xs-offset-7.key Subtotal
+    .col-xs-3.col-xs-offset-7.key.colored-text Subtotal
     .col-xs-2.val= with_currency @invoice.subtotal
   - if @invoice.discount_applied?
     .row
-      .col-xs-3.col-xs-offset-7.key Discount
+      .col-xs-3.col-xs-offset-7.key.colored-text Discount
       .col-xs-2.val= with_currency @invoice.discount
   .row
-    .col-xs-3.col-xs-offset-7.key Net total
+    .col-xs-3.col-xs-offset-7.key.colored-text Net total
     .col-xs-2.val= with_currency @invoice.total
   .row.big-border
-    .col-xs-3.col-xs-offset-7.key #{@invoice.including_vat_info}
+    .col-xs-3.col-xs-offset-7.key.colored-text #{@invoice.including_vat_info}
     .col-xs-2.val #{with_currency @invoice.total_vat}
   .row.bold
-    .col-xs-3.col-xs-offset-7.key Total
+    .col-xs-3.col-xs-offset-7.key.colored-text Total
     .col-xs-2.val= with_currency @invoice.calc_vat_total
 .row.terms
   .col-xs-4
-    h4 Payment
+    h4.colored-text Payment
     p= markdown @invoice.payment_info
-  .col-xs-4
+  .col-xs-4.colored-text
     - if @invoice.payment_terms
-      h4 Terms
+      h4.colored-text Terms
       p= markdown @invoice.payment_terms
-  .col-xs-4
+  .col-xs-4.colored-text
     - if @invoice.note
-      h4 Notes
+      h4.colored-text Notes
       = markdown @invoice.note
 .row
   .col-xs-12
@@ -105,3 +105,8 @@
       edit_invoice_path(@invoice), class: "btn btn-default btn-primary"
     = link_to "<i class='icon-cloud-download'></i> Download PDF".html_safe,
       pdf_export_invoice_path(@invoice), class: "btn btn-default"
+
+// Render custom stylesheets the user defined
+- if @invoice.user.invoice_default.custom_css.present?
+  css:
+    #{@invoice.user.invoice_default.custom_css}

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -65,6 +65,7 @@ en:
         payment_terms: "e.g. * Amount is due opon invoice receival."
         note: "e.g. * VAT-Number: 502123 or other important info in your country."
         vat: "e.g. 19.00"
+        custom_css: "e.g. .colored-text { color: #333; }"
       client:
         name: e.g. George Washington
         company_name: e.g. Evil Powers Ltd.

--- a/db/migrate/20170511175415_add_custom_css_to_invoice_defaults.rb
+++ b/db/migrate/20170511175415_add_custom_css_to_invoice_defaults.rb
@@ -1,0 +1,5 @@
+class AddCustomCssToInvoiceDefaults < ActiveRecord::Migration
+  def change
+    add_column :invoice_defaults, :custom_css, :text, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170417195659) do
+ActiveRecord::Schema.define(version: 20170511175415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,8 +84,9 @@ ActiveRecord::Schema.define(version: 20170417195659) do
     t.text     "payment_info"
     t.text     "note"
     t.integer  "user_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.text     "custom_css",    default: ""
   end
 
   create_table "invoices", force: :cascade do |t|


### PR DESCRIPTION
Users are now able to specify custom css for their invoices to adjust the look and feel matching their CI.

![image](https://cloud.githubusercontent.com/assets/816859/25964776/4148b4ee-3686-11e7-98f9-4e2e7ce44492.png)
